### PR TITLE
Add LIBS in src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,3 +5,4 @@ LDADD = -lncurses
 bin_PROGRAMS = nudoku
 nudoku_SOURCES = main.c sudoku.c sudoku.h
 AM_CPPFLAGS = -DLOCALEDIR=\""$(localedir)"\"
+LIBS = @LIBINTL@


### PR DESCRIPTION
A link error occurs on macOS because the linker flag for libintl is missing.