### PR TITLE
Small display support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ zypper in nudoku
 
 ### From Source ###
 
-#### Dependency ####
+#### Dependencies ####
+- gettext
 - ncurses
 
 #### Compilation ####

--- a/src/main.c
+++ b/src/main.c
@@ -33,12 +33,43 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 //#define VERSION				"0.1" //gets set via autotools
 #define GRID_LINES				19
 #define GRID_COLS				37
+
+#ifndef SMALL_DISPLAY
 #define GRID_Y					3
+#endif
+
+#ifdef SMALL_DISPLAY
+#define GRID_Y					1
+#endif
+
+#ifndef SMALL_DISPLAY
 #define GRID_X					3
+#endif
+
+#ifdef SMALL_DISPLAY
+#define GRID_X					1
+#endif
+
 #define INFO_LINES				19
 #define INFO_COLS				20
+
+#ifndef SMALL_DISPLAY
 #define INFO_Y					3
-#define INFO_X					GRID_X + GRID_COLS + 5
+#endif
+
+#ifdef SMALL_DISPLAY
+#define INFO_Y					2
+#endif
+
+#ifndef SMALL_DISPLAY
+#define INFO_INDENT				5
+#endif
+
+#ifdef SMALL_DISPLAY
+#define INFO_INDENT				1
+#endif
+
+#define INFO_X					GRID_X + GRID_COLS + INFO_INDENT
 #define GRID_NUMBER_START_Y		1
 #define GRID_NUMBER_START_X		2
 #define GRID_LINE_DELTA			4


### PR DESCRIPTION
Hi,

I have made some changes to make Nudoku playable on the 3.5" display I have attached to my Raspberry Pi.

The changes can be activated by defining SMALL_DISPLAY. I have been doing this by passing CPPFLAGS into configure.

Commit 2e5180b removes empty space from around the screen, making the game board and info box to the right _just_ fit onto the 3.5" display.

Commit cb3ed2b makes the very top line of the screen display the status message if there is one, or else it's the top border of the game board. Once a message is displays it is dismissed and replaced by the top border of the game board on the next keystroke.

Commit 28aa38a is a small change to the docs as I found I had to install gettext when compiling on Raspbian, so I've added it as a dependency.

Yours sincerely,
Dave Wilson (Jeroanan).


