### PR TITLE
Add snapcraft.yaml (support snap packaging)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: nudoku
+version: master
+summary: ncurses based sudoku game
+description: nudoku is a ncurses based sudoku game.
+
+confinement: strict
+
+apps:
+  nudoku:
+    command: nudoku
+
+parts:
+  nudoku:
+    source: https://github.com/jubalh/nudoku/archive/1.0.0.tar.gz
+    plugin: autotools
+    build-packages:
+      - libncurses-dev


### PR DESCRIPTION
I thought I'd add a snapcraft.yaml file to support building a snap for nudoku. Once this file is added, someone will still need to add this snap to the snap store[1]. 

[1] https://docs.snapcraft.io/c-c-applications/7817