### PR TITLE
Define a minimum gettext version rather than an exact one

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,8 +51,9 @@ AC_CHECK_HEADERS([stdlib.h string.h unistd.h])
 AC_CHECK_HEADER_STDBOOL
 
 # Set gettext files
+AM_GNU_GETTEXT_VERSION([0.19.6])
+AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.6])
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.19])
 
 # Checks for library functions.
 AC_FUNC_MALLOC


### PR DESCRIPTION
This PR prevents an error caused by the `Makefile.in.in` being for the exact gettext version specified in `configure.ac`, but the autoconf macros used being from whatever the latest version available on the system is.

Example:
```
Making all in po
*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.19 but the autoconf macros are from gettext version 0.20
make[1]: *** [stamp-po] Error 1
make: *** [all-recursive] Error 1
```

Leaving `AM_GNU_GETTEXT_VERSION` to act as a fall back but it will not be used if a version of `autopoint` that supports `AM_GNU_GETTEXT_REQUIRE_VERSION` is present.

`0.19` had to be bumped to at least `0.19.6` as that is where `AM_GNU_GETTEXT_REQUIRE_VERSION` was first introduced.