### PR TITLE
Add install info for macOS to GitHub Pages 🍏

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,5 +27,6 @@ As of now nudoku is also in the official repositores of:
 * Fedora
 * Gentoo
 * Ubuntu (based on Debian stretch)
+* Homebrew
 
 If you don't run any of these, well, go read the [readme](https://github.com/jubalh/nudoku/blob/master/README.md).


### PR DESCRIPTION
[The Missing Package Manager for macOS (or Linux)](https://brew.sh/)

[nudoku formula](https://formulae.brew.sh/formula/nudoku)

```bash
brew install nudoku
```