### PR TITLE
Add call to PKG_PROG_PKG_CONFIG and pkg-check ncurses libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,9 @@ AC_INIT([nudoku], [2.1.0], [jubalh@iodoru.org])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE([foreign])
 
+# Check for pkg-config
+PKG_PROG_PKG_CONFIG()
+
 # Checks for programs.
 AC_PROG_CC
 # Use C99.
@@ -35,9 +38,9 @@ the cairo development libraries, or compile without support (--disable-cairo)
 fi
 
 have_wide_ncurses=no
-AC_CHECK_LIB(ncursesw, initscr, [have_wide_ncurses=yes])
+PKG_CHECK_MODULES([ncursesw], [ncursesw], [have_wide_ncurses=yes], [])
 if test $have_wide_ncurses = no; then
-   AC_CHECK_LIB(ncurses, initscr, [], [
+   PKG_CHECK_MODULES([ncurses], [ncurses], [], [ 
    echo "nudoku requires ncurses"
    exit 1
    ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,9 +2,9 @@
 #-DDEBUG
 
 if HAVE_WIDE_NCURSES
-nudoku_LDADD = -lncursesw
+nudoku_LDADD = ${ncursesw_LIBS}
 else
-nudoku_LDADD = -lncurses
+nudoku_LDADD = ${ncurses_LIBS}
 endif
 bin_PROGRAMS = nudoku
 nudoku_SOURCES = main.c sudoku.c sudoku.h


### PR DESCRIPTION
Hello,

on Gentoo we had Issues with a missing path to pkg-check during the build process (see: https://bugs.gentoo.org/764497)
Adding the environment variable PKG_CONFIG was a work-around to avoid this.

Adding a call to PKG_PROG_PKG_CONFIG solved the issue.
We also had to check for ncurses and ncursesw via pkg-check.

Thanks, Philipp
