### PR TITLE
build: fix variable scope issue in undo functionality

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -708,18 +708,20 @@ int main(int argc, char *argv[])
 				}
 				break;
 			case 'u': // Undo
-				move_t old_move;
-				if (undo_stack_pop(&old_move))
-				{	// Stack empty
+				{
+					move_t old_move;
+					if (undo_stack_pop(&old_move))
+					{	// Stack empty
+						break;
+					}
+					x = old_move.x;
+					y = old_move.y;
+					posy = (y-GRID_NUMBER_START_Y)/GRID_COL_DELTA;
+					posx = (x-GRID_NUMBER_START_X)/GRID_LINE_DELTA;
+					user_board[posy*9+posx] = old_move.prev_val;
+					fill_grid(user_board, plain_board, x, y);
 					break;
 				}
-				x = old_move.x;
-				y = old_move.y;
-				posy = (y-GRID_NUMBER_START_Y)/GRID_COL_DELTA;
-				posx = (x-GRID_NUMBER_START_X)/GRID_LINE_DELTA;
-				user_board[posy*9+posx] = old_move.prev_val;
-				fill_grid(user_board, plain_board, x, y);
-				break;
 
 			default:
 				break;
@@ -755,4 +757,3 @@ int main(int argc, char *argv[])
 	endwin();
 	return EXIT_SUCCESS;
 }
-


### PR DESCRIPTION
see the following build failure in https://github.com/Homebrew/homebrew-core/pull/170273

```
  main.c:711:5: error: expected expression
                                  move_t old_move;
                                  ^
  main.c:712:25: error: use of undeclared identifier 'old_move'
                                  if (undo_stack_pop(&old_move))
                                                      ^
  main.c:716:9: error: use of undeclared identifier 'old_move'
                                  x = old_move.x;
                                      ^
  main.c:717:9: error: use of undeclared identifier 'old_move'
                                  y = old_move.y;
                                      ^
  main.c:720:31: error: use of undeclared identifier 'old_move'
                                  user_board[posy*9+posx] = old_move.prev_val;
                                                            ^
  5 errors generated.
```