### PR TITLE
Fix build with gettext 0.24.1+

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@
 AC_PREREQ([2.69])
 AC_INIT([nudoku], [5.0.0], [jubalh@iodoru.org])
 AC_CONFIG_SRCDIR([src/main.c])
+AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([foreign])
 
 # Check for pkg-config


### PR DESCRIPTION
Since gettext 0.24.1, gettext.m4 is no longer accessible by `ACLOCAL_PATH`. We specify `AC_CONFIG_MACRO_DIRS` here so that the m4 file is copied to the folder during autoreconf. This is a one-line backward-compatible change.

The issue was reported in https://github.com/NixOS/nixpkgs/issues/427269.