### PR TITLE
update: refining Vietnamese translation

### DIFF
--- a/po/vi.po
+++ b/po/vi.po
@@ -212,7 +212,7 @@ msgstr " với sự trợ giúp của %d gợi ý"
 
 #: src/main.c:821
 msgid "Correct so far"
-msgstr "Số ô đúng hiện tại"
+msgstr "Tất cả các ô hiện tại đều đúng"
 
 #: src/main.c:851
 msgid "Provided hint"


### PR DESCRIPTION
This pull request updates the Vietnamese translation for the "Correct so far" message to make it clearer and more accurate.

- Localization update:
  * In `po/vi.po`, changed the translation of "Correct so far" from "Số ô đúng hiện tại" ("Number of correct cells so far") to "Tất cả các ô hiện tại đều đúng" ("All current cells are correct"), providing a clearer and more grammatically accurate message.