### PR TITLE
Add PDF paper size adjustment option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,14 @@ src/.deps/
 src/Makefile
 src/Makefile.in
 src/nudoku
+m4/
+config.*
+ABOUT-NLS
+
+# Restrict translation files uploaded to repo
+po/
+!po/LINGUAS
+!po/Makevars
+!po/POTFILES.in
+!po/nudoku.pot
+!po/*.po

--- a/man/nudoku.6
+++ b/man/nudoku.6
@@ -82,7 +82,7 @@ Example: -p riddle.pdf
 
 .BR \-n
 Number of sudokuks to put in PDF.
-This can only be used with -p
+This can only be used with -p.
 Example: -p riddle.pdf -n 8
 
 .BR \-i
@@ -92,7 +92,7 @@ Example: -i sudoku.png
 
 .BR \-S
 Paper size for PDF output.
-Accepted values are: 'a4' (default) or 'letter'. This can only be used with -p
+Accepted values are: 'a4' (default) or 'letter'. This can only be used with -p.
 Example: -p riddle.pdf -S letter
 
 .SH BUGS

--- a/man/nudoku.6
+++ b/man/nudoku.6
@@ -90,6 +90,11 @@ Output PNG image.
 Puts a single sudoku into an PNG image file. File name needs to follow.
 Example: -i sudoku.png
 
+.BR \-S
+Paper size for PDF output.
+Accepted values are: 'a4' (default) or 'letter'. This can only be used with -p
+Example: -p riddle.pdf -S letter
+
 .SH BUGS
 No known bugs.
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: 2018-05-03 10:12-0300\n"
 "Last-Translator: Emanuel Dubor <emanueldubor@gmail.com>\n"
 "Language-Team: German\n"
@@ -17,84 +17,94 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
 "\n"
 msgstr ""
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr ""
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr ""
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr ""
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr ""
 
-#: src/main.c:112
-#, c-format
-msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
-msgstr ""
-
-#: src/main.c:113
-#, c-format
-msgid "-s stream:\t\tUser provided sudoku stream\n"
-msgstr ""
-
-#: src/main.c:114
-#, c-format
-msgid "-r resume:\t\tResume the last saved game\n"
-msgstr ""
-
 #: src/main.c:115
 #, c-format
-msgid "-p filename:\t\tOutput PDF\n"
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
 msgstr ""
 
 #: src/main.c:116
 #, c-format
-msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
+msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
 msgstr ""
 
 #: src/main.c:117
 #, c-format
+msgid "-s stream:\t\tUser provided sudoku stream\n"
+msgstr ""
+
+#: src/main.c:118
+#, c-format
+msgid "-r resume:\t\tResume the last saved game\n"
+msgstr ""
+
+#: src/main.c:119
+#, c-format
+msgid "-p filename:\t\tOutput PDF\n"
+msgstr ""
+
+#: src/main.c:120
+#, c-format
+msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
+msgstr ""
+
+#: src/main.c:121
+#, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr ""
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "Zeichen %c an Position %d ist nicht erlaubt.\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "Der Stream muss %d Zeichen lang sein.\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "Stream stellt kein gültiges Sudoku-Puzzle dar.\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr ""
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -102,7 +112,7 @@ msgstr ""
 "Ihr Terminal unterstützt keine Farben.\n"
 "Probieren Sie die Option nocolor (-c) aus.\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -111,23 +121,23 @@ msgstr ""
 "Niveau: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "Bewegung\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - Nach links bewegen\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - Nach unten gehen\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - Nach oben gehen\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
@@ -135,106 +145,106 @@ msgstr ""
 " l - Nach rechts bewegen\n"
 "\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "Befehle\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - Überprüfen Sie die Lösung\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - Gib einen Hinweis\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - Umschaltmarken\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - Neues Puzzle\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr ""
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - Verlassen\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - Neu zeichnen\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - Puzzle lösen\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - Nummer löschen\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr ""
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr ""
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
 msgstr ""
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "Puzzle lösen..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "Gelöst"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "Generiere Sudoku..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "Nicht richtig"
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr " mit Hilfe von %d Tipps"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr "Soweit richtig"
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "Tipp gegeben"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr ""
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr ""
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "schwer"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "normal"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "einfach"
 

--- a/po/es.po
+++ b/po/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku 1.0.0\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: 2018-04-26 19:03-0300\n"
 "Last-Translator: ramshell <ramshellcinox@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
@@ -25,77 +25,87 @@ msgstr ""
 "nudoku [option]\n"
 "\n"
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr "Opciones:\n"
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr "-h help:\t\tImprimir esta ayuda\n"
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr "-v version:\t\tImprimir version\n"
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr "-c nocolor:\t\tNo use colores\n"
 
-#: src/main.c:112
-#, c-format
-msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
-msgstr "-d dificultad:\t\tElige entre: facil, normal, dificil\n"
-
-#: src/main.c:113
-#, c-format
-msgid "-s stream:\t\tUser provided sudoku stream\n"
-msgstr "-s datos:\t\tDatos dados por el usuario\n"
-
-#: src/main.c:114
-#, c-format
-msgid "-r resume:\t\tResume the last saved game\n"
-msgstr ""
-
 #: src/main.c:115
 #, c-format
-msgid "-p filename:\t\tOutput PDF\n"
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
 msgstr ""
 
 #: src/main.c:116
 #, c-format
+msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
+msgstr "-d dificultad:\t\tElige entre: facil, normal, dificil\n"
+
+#: src/main.c:117
+#, c-format
+msgid "-s stream:\t\tUser provided sudoku stream\n"
+msgstr "-s datos:\t\tDatos dados por el usuario\n"
+
+#: src/main.c:118
+#, c-format
+msgid "-r resume:\t\tResume the last saved game\n"
+msgstr ""
+
+#: src/main.c:119
+#, c-format
+msgid "-p filename:\t\tOutput PDF\n"
+msgstr ""
+
+#: src/main.c:120
+#, c-format
 msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
 msgstr ""
 
-#: src/main.c:117
+#: src/main.c:121
 #, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr ""
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "No se permite el caracter %c en la posicion %d.\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "Los datos deben tener como maximo %d characteres.\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "Los datos no representan un sudoku valido.\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr ""
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -103,7 +113,7 @@ msgstr ""
 "Tu terminal no soporta colores.\n"
 "Prueba la opcion nocolor (-c).\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -112,127 +122,127 @@ msgstr ""
 "nivel: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "Movimiento\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - Mover a la izq\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - Mover a abajo\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - Mover a arriba\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
 msgstr " l - Mover a la der\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "Comandos\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - Verificar sol\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - Dar una pista\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - Activar marcas\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - Nuevo sudoku\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr ""
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - Salir\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - Redibujar\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - Resolver sudoku\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - Borrar numero\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr ""
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr ""
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
 msgstr ""
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "Resolviendo sudoku..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "Resuelto"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "Generando sudoku..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "Incorrecto"
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr " con la ayuda de %d pistas"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr "Correctas hasta ahora"
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "Pistas dadas"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr ""
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr ""
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "dificil"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "normal"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "facil"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: 2019-04-11 14:02+0100\n"
 "Last-Translator: Aurelien Aptel <aurelien.aptel@gmail.com>\n"
 "Language-Team: French\n"
@@ -17,84 +17,94 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
 "\n"
 msgstr ""
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr ""
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr ""
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr ""
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr ""
 
-#: src/main.c:112
-#, c-format
-msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
-msgstr ""
-
-#: src/main.c:113
-#, c-format
-msgid "-s stream:\t\tUser provided sudoku stream\n"
-msgstr ""
-
-#: src/main.c:114
-#, c-format
-msgid "-r resume:\t\tResume the last saved game\n"
-msgstr ""
-
 #: src/main.c:115
 #, c-format
-msgid "-p filename:\t\tOutput PDF\n"
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
 msgstr ""
 
 #: src/main.c:116
 #, c-format
-msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
+msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
 msgstr ""
 
 #: src/main.c:117
 #, c-format
+msgid "-s stream:\t\tUser provided sudoku stream\n"
+msgstr ""
+
+#: src/main.c:118
+#, c-format
+msgid "-r resume:\t\tResume the last saved game\n"
+msgstr ""
+
+#: src/main.c:119
+#, c-format
+msgid "-p filename:\t\tOutput PDF\n"
+msgstr ""
+
+#: src/main.c:120
+#, c-format
+msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
+msgstr ""
+
+#: src/main.c:121
+#, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr ""
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "Le caractère %c à la position %d n'est pas authorisé.\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "Le stream doit faire %d caractères.\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "Le stream ne représente pas un sudoku valide.\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr ""
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -102,7 +112,7 @@ msgstr ""
 "Votre terminal ne supporte pas les couleurs.\n"
 "Essayez l'option nocolor (-c).\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -111,23 +121,23 @@ msgstr ""
 "Niveau: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "Mouvement\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - Gauche\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - Bas\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - Haut\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
@@ -135,106 +145,106 @@ msgstr ""
 " l - Droite\n"
 "\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "Commandes\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - Vérifie la solution\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - Donne un indice\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - Montre les marques\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - Nouveau Puzzle\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr ""
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - Quitter\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - Rafraichir\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - Résout le puzzle\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - Supprime un chiffre\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr ""
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr ""
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
 msgstr ""
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "Résolution du puzzle..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "Résolu"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "Génération du sudoku..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "Invalide"
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr " avec l'aide de %d astuces"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr "Correct pour l'instant"
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "Indice donné"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr ""
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr ""
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "difficile"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "normal"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "facile"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: 2020-09-01 21:19+0900\n"
 "Last-Translator: cmplstofB <20594300+cmplstofB@users.noreply.github.com>\n"
 "Language-Team: Japanese\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
@@ -25,77 +25,87 @@ msgstr ""
 "nudoku [オプション]\n"
 "\n"
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr "オプション:\n"
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr "-h:\t\tこの手引きを表示\n"
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr "-v:\t\t版を表示\n"
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr "-c:\t\t着色しない\n"
 
-#: src/main.c:112
-#, c-format
-msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
-msgstr "-d 難易度:\t\t難易度を選択: easy, normal, hard\n"
-
-#: src/main.c:113
-#, c-format
-msgid "-s stream:\t\tUser provided sudoku stream\n"
-msgstr "-s 版面:\t\t数独の盤面を指定する\n"
-
-#: src/main.c:114
-#, c-format
-msgid "-r resume:\t\tResume the last saved game\n"
-msgstr ""
-
 #: src/main.c:115
 #, c-format
-msgid "-p filename:\t\tOutput PDF\n"
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
 msgstr ""
 
 #: src/main.c:116
 #, c-format
+msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
+msgstr "-d 難易度:\t\t難易度を選択: easy, normal, hard\n"
+
+#: src/main.c:117
+#, c-format
+msgid "-s stream:\t\tUser provided sudoku stream\n"
+msgstr "-s 版面:\t\t数独の盤面を指定する\n"
+
+#: src/main.c:118
+#, c-format
+msgid "-r resume:\t\tResume the last saved game\n"
+msgstr ""
+
+#: src/main.c:119
+#, c-format
+msgid "-p filename:\t\tOutput PDF\n"
+msgstr ""
+
+#: src/main.c:120
+#, c-format
 msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
 msgstr ""
 
-#: src/main.c:117
+#: src/main.c:121
 #, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr ""
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "文字%cは位置%dにあってはなりません。\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "版面は%d文字以上なくてはなりません。\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "指定された版面は妥当な数独の問題を表わせません。\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr ""
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -103,7 +113,7 @@ msgstr ""
 "お使いの端末は着色に対応していません。\n"
 "無着色 (-c) オプションをお試しください。\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -112,23 +122,23 @@ msgstr ""
 "難易度: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "移  動\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - 左に移動\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - 下に移動\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - 上に移動\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
@@ -136,105 +146,105 @@ msgstr ""
 " l - 右に移動\n"
 "\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "命  令\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - 解答を確かめる\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - 手掛かりを見る\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - 印を付ける/外す\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - 新しい問題\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr ""
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - 終了\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - 再描画\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - 問題を解く\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - 数字を消す\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr ""
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr ""
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
 msgstr ""
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "問題を解いています..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "正解です"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "問題を生成しています..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "不正解です"
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr "（手掛かりを%d回見ました）"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr "現時点では正解です"
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "手掛りを得ました"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr ""
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr ""
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "難"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "中"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "易"

--- a/po/ka.po
+++ b/po/ka.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku 4.0.1\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: 2026-02-21 23:20+0100\n"
 "Last-Translator: Ekaterine Papava <papava.e@gtu.ge>\n"
 "Language-Team: Georgian <(nothing)>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
@@ -25,77 +25,89 @@ msgstr ""
 "nudoku [პარამეტრი]\n"
 "\n"
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr "პარამეტრები:\n"
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr "-h help:\t\tამ დახმარების გამოტანა\n"
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr "-v version:\t\tვერსიის გამოტანა\n"
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr "-c nocolor:\t\tფერების გამოტანა არ მოხდება\n"
 
-#: src/main.c:112
+#: src/main.c:115
+#, c-format
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
+msgstr ""
+
+#: src/main.c:116
 #, c-format
 msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
 msgstr "-d difficulty:\t\tაირჩიეთ: იოლი, ნორმალური, რთული\n"
 
-#: src/main.c:113
+#: src/main.c:117
 #, c-format
 msgid "-s stream:\t\tUser provided sudoku stream\n"
 msgstr "-s stream:\t\tმომხმარებლის მოწოდებული სუდოკუს ნაკადი\n"
 
-#: src/main.c:114
+#: src/main.c:118
 #, c-format
 msgid "-r resume:\t\tResume the last saved game\n"
 msgstr "-r resume:\t\tბოლო შენახული თამაშის გაგრძელება\n"
 
-#: src/main.c:115
+#: src/main.c:119
 #, c-format
 msgid "-p filename:\t\tOutput PDF\n"
 msgstr "-p filename:\t\tგატანა PDF-ში\n"
 
-#: src/main.c:116
+#: src/main.c:120
 #, c-format
 msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
 msgstr "-n filename:\t\tPDF-ში ჩასალაგებელი სუდოკუების რაოდენობა\n"
 
-#: src/main.c:117
+#: src/main.c:121
 #, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr "-i filename:\t\tPNG გამოსახულების გამოტანა\n"
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "სიმბოლო %c მდებარეობაზე %d დაშვებული არაა.\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "ნაკადი %d სიმბოლოს უნდა შეიცავდეს.\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "ნაკადი სწორი სუდოკუს პაზლი არაა.\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
-msgstr "თამაშის შენახული არ არსებობს, ან დაზიანებულია. სცადეთ, თამაში თავიდან დაიწყოთ.\n"
+msgstr ""
+"თამაშის შენახული არ არსებობს, ან დაზიანებულია. სცადეთ, თამაში თავიდან "
+"დაიწყოთ.\n"
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -103,7 +115,7 @@ msgstr ""
 "თქვენს ტერმინალს ფერების მხარდაჭერა არ აქვს.\n"
 "სცადეთ პარამეტრი ფერების გარეშე (-c).\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -112,23 +124,23 @@ msgstr ""
 "დონე: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "გადაადგილება\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - გადაადგილება მარცხნივ\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - ჩამოწევა\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - აწევა\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
@@ -136,105 +148,106 @@ msgstr ""
 " l - გადაადგილება მარჯვნივ\n"
 "\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "ბრძანებები\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - გადაწყვეტილების შემოწმება\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - მინიშნებების მიცემა\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - ნიშნების გადართვა\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - ახალი პაზლი\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr " G - შენახვა\n"
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - გასვლა\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - თავიდან დახატვა\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - პაზლის ამოხსნა\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - რიცხვის წაშლა\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr " u - წინა ქმედების გაუქმება\n"
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr "nudoku-ს აგებისას cairo-ის მხარდაჭერა ჩართული არ იყო.\n"
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
-msgstr "გამოტანის ფუნქციის გამოსაყენებლად აგებისას ჩართეთ პარამეტრი --enable-cairo.\n"
+msgstr ""
+"გამოტანის ფუნქციის გამოსაყენებლად აგებისას ჩართეთ პარამეტრი --enable-cairo.\n"
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "პაზლის ამოხსნა..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "ამოხსნილი"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "პაზლის გენერაცია..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "არასწორია"
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr " %d მინიშნების დახმარებით"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr "ჯერჯერობით სწორია"
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "მოწოდებული მინიშნება"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr "შენახულია!"
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr "თამაშის შენახვა შეუძლებელია!"
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "მაგარი"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "ნორმალური"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "მარტივი"

--- a/po/nudoku.pot
+++ b/po/nudoku.pot
@@ -5,9 +5,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: nudoku 4.0.1\n"
+"Project-Id-Version: nudoku 7.0.0\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,217 +16,227 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
 "\n"
 msgstr ""
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr ""
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr ""
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr ""
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr ""
 
-#: src/main.c:112
-#, c-format
-msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
-msgstr ""
-
-#: src/main.c:113
-#, c-format
-msgid "-s stream:\t\tUser provided sudoku stream\n"
-msgstr ""
-
-#: src/main.c:114
-#, c-format
-msgid "-r resume:\t\tResume the last saved game\n"
-msgstr ""
-
 #: src/main.c:115
 #, c-format
-msgid "-p filename:\t\tOutput PDF\n"
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
 msgstr ""
 
 #: src/main.c:116
 #, c-format
-msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
+msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
 msgstr ""
 
 #: src/main.c:117
 #, c-format
+msgid "-s stream:\t\tUser provided sudoku stream\n"
+msgstr ""
+
+#: src/main.c:118
+#, c-format
+msgid "-r resume:\t\tResume the last saved game\n"
+msgstr ""
+
+#: src/main.c:119
+#, c-format
+msgid "-p filename:\t\tOutput PDF\n"
+msgstr ""
+
+#: src/main.c:120
+#, c-format
+msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
+msgstr ""
+
+#: src/main.c:121
+#, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr ""
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr ""
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr ""
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr ""
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr ""
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
 msgstr ""
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
 "\n"
 msgstr ""
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr ""
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr ""
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr ""
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr ""
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
 msgstr ""
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr ""
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr ""
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr ""
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr ""
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr ""
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr ""
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr ""
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr ""
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr ""
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr ""
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr ""
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr ""
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
 msgstr ""
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr ""
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr ""
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr ""
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr ""
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr ""
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr ""
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr ""
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr ""
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr ""
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr ""
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr ""
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Max Vetrov <maxvetrov555@yandex.ru>\n"
 "Language-Team: Russian\n"
@@ -17,84 +17,94 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
 "\n"
 msgstr ""
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr ""
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr ""
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr ""
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr ""
 
-#: src/main.c:112
-#, c-format
-msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
-msgstr ""
-
-#: src/main.c:113
-#, c-format
-msgid "-s stream:\t\tUser provided sudoku stream\n"
-msgstr ""
-
-#: src/main.c:114
-#, c-format
-msgid "-r resume:\t\tResume the last saved game\n"
-msgstr ""
-
 #: src/main.c:115
 #, c-format
-msgid "-p filename:\t\tOutput PDF\n"
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
 msgstr ""
 
 #: src/main.c:116
 #, c-format
-msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
+msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
 msgstr ""
 
 #: src/main.c:117
 #, c-format
+msgid "-s stream:\t\tUser provided sudoku stream\n"
+msgstr ""
+
+#: src/main.c:118
+#, c-format
+msgid "-r resume:\t\tResume the last saved game\n"
+msgstr ""
+
+#: src/main.c:119
+#, c-format
+msgid "-p filename:\t\tOutput PDF\n"
+msgstr ""
+
+#: src/main.c:120
+#, c-format
+msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
+msgstr ""
+
+#: src/main.c:121
+#, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr ""
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "Символ %c на позиции %d не поддерживается.\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "Поток должен быть длиною %d символов.\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "Поток не является судоку-головоломкой.\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr ""
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -102,7 +112,7 @@ msgstr ""
 "Ваш терминал не поддерживает цвета.\n"
 "Попробуйте опцию без цвета (-c).\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -111,23 +121,23 @@ msgstr ""
 "Уровень: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "Движение\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - Влево\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - Вниз\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - Вверх\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
@@ -135,106 +145,106 @@ msgstr ""
 " l - Вправо\n"
 "\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "Команды\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - Проверить решение\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - Дать подсказку\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - Переключить метки\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - Новая головоломка\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr ""
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - Выход\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - Перерисовка\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - Решить головоломку\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - Удалить число\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr ""
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr ""
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
 msgstr ""
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "Решение головоломки..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "Решено"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "Генерация головоломки..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "Не правильно"
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr " с помощью %d подсказок"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr ""
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "Предоставлена подсказка"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr ""
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr ""
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "Сложный"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "Нормальный"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "Легкий"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku 1.0.0\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: 2024-09-08 18:46+0300\n"
 "Last-Translator: Oğuz Ersen <oguz@ersen.moe>\n"
 "Language-Team: Turkish <tr>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Gtranslator 46.1\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
@@ -26,77 +26,87 @@ msgstr ""
 "nudoku [seçenek]\n"
 "\n"
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr "Seçenekler:\n"
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr "-h:\t\tYardım metnini yazdır\n"
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr "-v:\t\tSürüm numarasını yazdır\n"
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr "-c:\t\tRenkler kullanılmasın\n"
 
-#: src/main.c:112
+#: src/main.c:115
+#, c-format
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
+msgstr ""
+
+#: src/main.c:116
 #, c-format
 msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
 msgstr "-d zorluk:\t\tZorluk derecesini seç: easy, normal, hard\n"
 
-#: src/main.c:113
+#: src/main.c:117
 #, c-format
 msgid "-s stream:\t\tUser provided sudoku stream\n"
 msgstr "-s tahta:\t\tBelirtilen sudoku tahtasını kullan\n"
 
-#: src/main.c:114
+#: src/main.c:118
 #, c-format
 msgid "-r resume:\t\tResume the last saved game\n"
 msgstr "-r resume:\t\tSon kaydedilen oyuna devam et\n"
 
-#: src/main.c:115
+#: src/main.c:119
 #, c-format
 msgid "-p filename:\t\tOutput PDF\n"
 msgstr "-p dosyaadı:\t\tPDF olarak dışa aktar\n"
 
-#: src/main.c:116
+#: src/main.c:120
 #, c-format
 msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
 msgstr "-n dosyaadı:\t\tPDF dosyasına yazılacak sudoku sayısı\n"
 
-#: src/main.c:117
+#: src/main.c:121
 #, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr "-i dosyaadı:\t\tPNG resmi olarak dışa aktar\n"
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "%c karakterine %d konumunda izin verilmiyor.\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "Tahta %d karakter uzunluğunda olmalıdır.\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "Tahta geçerli bir sudoku bulmacası değil.\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr "Oyun kaydı eksik veya bozuk, yeni oyun başlatmayı deneyin.\n"
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -104,7 +114,7 @@ msgstr ""
 "Terminaliniz renkleri desteklemiyor.\n"
 "Renksiz (-c) seçeneğini deneyin.\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -113,23 +123,23 @@ msgstr ""
 "seviye: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "Hareket\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - Sola git\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - Aşağı git\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - Yukarı git\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
@@ -137,106 +147,106 @@ msgstr ""
 " l - Sağa git\n"
 "\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "Komutlar\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - Çözümü denetle\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - İpucu ver\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - İşaretleri aç/kapat\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - Yeni bulmaca\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr " G - Kaydet\n"
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - Çıkış\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - Yeniden çiz\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - Bulmacayı çöz\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - Sayıyı sil\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr " u - Önceki eylemi geri al\n"
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr "nudoku cairo desteği olmadan derlendi.\n"
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
 msgstr ""
 "Dışa aktarma özelliğini kullanmak için lütfen --enable-cairo ile derleyin.\n"
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "Bulmaca çözülüyor..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "Çözüldü"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "Bulmaca oluşturuluyor..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "Doğru değil"
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr "%d ipucu yardımıyla"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr "Şimdiye kadar doğru"
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "İpucu verildi"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr "Kaydedildi!"
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr "Oyun kaydedilemiyor!"
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "zor"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "normal"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "kolay"

--- a/po/uk.po
+++ b/po/uk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku 4.0.1\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: 2024-08-24 10:05+0200\n"
 "Last-Translator: Oleksii Stroganov <merv1n@proton.me>\n"
 "Language-Team: Ukrainian <uk>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "(n%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Generator: Gtranslator 45.3\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
@@ -28,77 +28,87 @@ msgstr ""
 "nudoku [опції]\n"
 "\n"
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr "Опції:\n"
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr "-h довідка:\t\tНадрукувати цю довідку\n"
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr "-v версія:\t\tНадрукувати версію\n"
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr "-c без кольорів:\t\tНе використовувати кольори\n"
 
-#: src/main.c:112
+#: src/main.c:115
+#, c-format
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
+msgstr ""
+
+#: src/main.c:116
 #, c-format
 msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
 msgstr "-d складність:\t\tОбрати рівень: easy, normal, hard\n"
 
-#: src/main.c:113
+#: src/main.c:117
 #, c-format
 msgid "-s stream:\t\tUser provided sudoku stream\n"
 msgstr "-s потік:\t\tНаданий користувачем поток судоку\n"
 
-#: src/main.c:114
+#: src/main.c:118
 #, c-format
 msgid "-r resume:\t\tResume the last saved game\n"
 msgstr "-r продовжити:\t\tПродовжити останню збережену гру\n"
 
-#: src/main.c:115
+#: src/main.c:119
 #, c-format
 msgid "-p filename:\t\tOutput PDF\n"
 msgstr "-p файл:\t\tСтворити PDF документ\n"
 
-#: src/main.c:116
+#: src/main.c:120
 #, c-format
 msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
 msgstr "-n файл:\t\tКількість судоку у PDF\n"
 
-#: src/main.c:117
+#: src/main.c:121
 #, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr "-i файл:\t\tСтворити PNG світлину\n"
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "Символ %c в позиції %d не допускається.\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "Поток має бути %d символів у довжину.\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "Поток не є правильним судоку.\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr "Гра не була збережена або пошкоджена, спробуйте нову гру.\n"
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -106,7 +116,7 @@ msgstr ""
 "Цей термінал не підтримує кольори\n"
 "Спробуйте опцію без кольору (-c).\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -115,23 +125,23 @@ msgstr ""
 "Рівень: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "Переміщення\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - Ліворуч\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - Вниз\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - Вверх\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
@@ -139,109 +149,109 @@ msgstr ""
 " l - Праворуч\n"
 "\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "Команди\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - Перевірити судоку\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - Дати підсказку\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - Переключити позначки\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - Нова головоломка\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr " G - Зберегти\n"
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - Вийти\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - Оновити екран\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - Розв'язати головоломку\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - Видалити число\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr " u - Скасувати останню дію\n"
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr "nudoku cкомпільований без підтримки cairo.\n"
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
 msgstr ""
 "Для функціонування друку судоку використовуйте --enable-cairo при "
 "компіляції.\n"
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "Розв'язую головоломку..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "Розв'язано"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "Створюю головоломку..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "У вас помилка"
 
-#: src/main.c:813
+#: src/main.c:860
 #, fuzzy, c-format
 #| msgid " with the help of %d hints"
 #| msgid_plural " with the help of %d hints"
 msgid " with the help of %d hints"
 msgstr " зa допомогою %d підсказки"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr "Зараз правильно"
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "Ви використали підсказку"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr "Судоку збережено!"
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr "Не можу зберегти гру!"
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "складний"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "нормальний"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "легкий"

--- a/po/vi.po
+++ b/po/vi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nudoku 4.0.1\n"
 "Report-Msgid-Bugs-To: jubalh@iodoru.org\n"
-"POT-Creation-Date: 2024-08-24 09:59+0300\n"
+"POT-Creation-Date: 2026-04-04 23:30-0700\n"
 "PO-Revision-Date: 2026-03-10 11:51+0700\n"
 "Last-Translator: Benjamin Nguyen <ima.techmoocher@gmail.com>\n"
 "Language-Team: Vietnamese\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/main.c:107
+#: src/main.c:110
 #, c-format
 msgid ""
 "nudoku [option]\n"
@@ -24,77 +24,88 @@ msgstr ""
 "nudoku [tùy_chọn]\n"
 "\n"
 
-#: src/main.c:108
+#: src/main.c:111
 #, c-format
 msgid "Options:\n"
 msgstr "Tùy chọn:\n"
 
-#: src/main.c:109
+#: src/main.c:112
 #, c-format
 msgid "-h help:\t\tPrint this help\n"
 msgstr "-h help:\t\tHiển thị trợ giúp\n"
 
-#: src/main.c:110
+#: src/main.c:113
 #, c-format
 msgid "-v version:\t\tPrint version\n"
 msgstr "-v version:\t\tHiển thị phiên bản\n"
 
-#: src/main.c:111
+#: src/main.c:114
 #, c-format
 msgid "-c nocolor:\t\tDo not use colors\n"
 msgstr "-c nocolor:\t\tKhông hiển thị màu\n"
 
-#: src/main.c:112
+#: src/main.c:115
+#, c-format
+msgid "-o output:\t\tOutput stream (inverse of -s)\n"
+msgstr ""
+
+#: src/main.c:116
 #, c-format
 msgid "-d difficulty:\t\tChoose between: easy, normal, hard\n"
-msgstr "-d difficulty:\t\tChọn độ khó: easy (dễ), normal (thường), hard (khó)\n"
+msgstr ""
+"-d difficulty:\t\tChọn độ khó: easy (dễ), normal (thường), hard (khó)\n"
 
-#: src/main.c:113
+#: src/main.c:117
 #, c-format
 msgid "-s stream:\t\tUser provided sudoku stream\n"
 msgstr "-s stream:\t\tSử dụng câu đố do người dùng cung cấp\n"
 
-#: src/main.c:114
+#: src/main.c:118
 #, c-format
 msgid "-r resume:\t\tResume the last saved game\n"
 msgstr "-r resume:\t\tTiếp tục ván chơi được lưu gần nhất\n"
 
-#: src/main.c:115
+#: src/main.c:119
 #, c-format
 msgid "-p filename:\t\tOutput PDF\n"
 msgstr "-p filename:\t\tXuất file dưới dạng PDF\n"
 
-#: src/main.c:116
+#: src/main.c:120
 #, c-format
 msgid "-n filename:\t\tNumber of sudokus to put in PDF\n"
 msgstr "-n filename:\t\tSố lượng câu đố sudoku trong file PDF\n"
 
-#: src/main.c:117
+#: src/main.c:121
 #, c-format
 msgid "-i filename:\t\tOutput PNG image\n"
 msgstr "-i filename:\t\tXuất file dưới dạng PNG\n"
 
-#: src/main.c:131
+#: src/main.c:122
+#, c-format
+msgid "-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"
+msgstr ""
+
+#: src/main.c:136
 #, c-format
 msgid "Character %c at position %d is not allowed.\n"
 msgstr "Ký tự %c tại vị trí %d không hợp lệ.\n"
 
-#: src/main.c:139
+#: src/main.c:144
 #, c-format
 msgid "Stream has to be %d characters long.\n"
 msgstr "Chuỗi được cung cấp phải có độ dài %d ký tự.\n"
 
-#: src/main.c:145
+#: src/main.c:150
 #, c-format
 msgid "Stream does not represent a valid sudoku puzzle.\n"
 msgstr "Chuỗi được cung cấp không phải là một câu đố hợp lệ.\n"
 
-#: src/main.c:305
+#: src/main.c:321
 #, c-format
 msgid "Game save is missing or corrupted, try starting new game.\n"
 msgstr "Bản lưu bị thất lạc hoặc hư hỏng, vui lòng bắt đầu ván chơi khác.\n"
 
-#: src/main.c:375
+#: src/main.c:403
 msgid ""
 "Your terminal doesn't support colors.\n"
 "Try the nocolor (-c) option.\n"
@@ -102,7 +113,7 @@ msgstr ""
 "Terminal của bạn không hỗ trợ hiển thị màu.\n"
 "Hãy thử sử dụng tùy chọn nocolor (-c).\n"
 
-#: src/main.c:466
+#: src/main.c:494
 #, c-format
 msgid ""
 "level: %s\n"
@@ -111,23 +122,23 @@ msgstr ""
 "độ khó: %s\n"
 "\n"
 
-#: src/main.c:475
+#: src/main.c:503
 msgid "Movement\n"
 msgstr "Di chuyển\n"
 
-#: src/main.c:476
+#: src/main.c:504
 msgid " h - Move left\n"
 msgstr " h - Trái\n"
 
-#: src/main.c:477
+#: src/main.c:505
 msgid " j - Move down\n"
 msgstr " j - Xuống\n"
 
-#: src/main.c:478
+#: src/main.c:506
 msgid " k - Move up\n"
 msgstr " k - Lên\n"
 
-#: src/main.c:479
+#: src/main.c:507
 msgid ""
 " l - Move right\n"
 "\n"
@@ -135,105 +146,107 @@ msgstr ""
 " l - Phải\n"
 "\n"
 
-#: src/main.c:480
+#: src/main.c:508
 msgid "Commands\n"
 msgstr "Lệnh\n"
 
-#: src/main.c:481
+#: src/main.c:509
 msgid " c - Check solution\n"
 msgstr " c - Kiểm tra lời giải\n"
 
-#: src/main.c:482
+#: src/main.c:510
 msgid " H - Give a hint\n"
 msgstr " H - Gợi ý\n"
 
-#: src/main.c:485
+#: src/main.c:513
 msgid " m - Toggle marks\n"
 msgstr " m - Bật/Tắt đánh dấu\n"
 
-#: src/main.c:487
+#: src/main.c:515
 msgid " N - New puzzle\n"
 msgstr " N - Câu đố mới\n"
 
-#: src/main.c:488
+#: src/main.c:516
 msgid " G - Save\n"
 msgstr " G - Lưu\n"
 
-#: src/main.c:489
+#: src/main.c:517
 msgid " Q - Quit\n"
 msgstr " Q - Thoát\n"
 
-#: src/main.c:490
+#: src/main.c:518
 msgid " r - Redraw\n"
 msgstr " r - Vẽ lại màn hình\n"
 
-#: src/main.c:491
+#: src/main.c:519
 msgid " S - Solve puzzle\n"
 msgstr " S - Giải\n"
 
-#: src/main.c:492
+#: src/main.c:520
 msgid " x - Delete number\n"
 msgstr " x - Xóa số trong ô\n"
 
-#: src/main.c:493
+#: src/main.c:521
 msgid " u - Undo previous action\n"
 msgstr " u - Hoàn tác\n"
 
-#: src/main.c:652
+#: src/main.c:686
 #, c-format
 msgid "nudoku is compiled without cairo support.\n"
 msgstr "nudoku được biên dịch mà không hỗ trợ cairo.\n"
 
-#: src/main.c:653
+#: src/main.c:687
 #, c-format
 msgid "To use the output feature, please compile with --enable-cairo.\n"
-msgstr "Để sử dụng tính năng xuất file, vui lòng biên dịch với tùy chọn --enable-cairo.\n"
+msgstr ""
+"Để sử dụng tính năng xuất file, vui lòng biên dịch với tùy chọn --enable-"
+"cairo.\n"
 
-#: src/main.c:760
+#: src/main.c:807
 msgid "Solving puzzle..."
 msgstr "Đang giải..."
 
-#: src/main.c:766 src/main.c:808
+#: src/main.c:813 src/main.c:855
 msgid "Solved"
 msgstr "Giải hoàn tất"
 
-#: src/main.c:776
+#: src/main.c:823
 msgid "Generating puzzle..."
 msgstr "Đang tạo câu đố..."
 
-#: src/main.c:802
+#: src/main.c:849
 msgid "Not correct"
 msgstr "Không chính xác"
 
-#: src/main.c:813
+#: src/main.c:860
 #, c-format
 msgid " with the help of %d hints"
 msgstr " với sự trợ giúp của %d gợi ý"
 
-#: src/main.c:821
+#: src/main.c:868
 msgid "Correct so far"
 msgstr "Tất cả các ô hiện tại đều đúng"
 
-#: src/main.c:851
+#: src/main.c:898
 msgid "Provided hint"
 msgstr "Đã cung cấp gợi ý"
 
-#: src/main.c:864
+#: src/main.c:911
 msgid "Saved!"
 msgstr "Lưu thành công!"
 
-#: src/main.c:867
+#: src/main.c:914
 msgid "Can't save the game!"
 msgstr "Lưu không thành công!"
 
-#: src/sudoku.c:251
+#: src/sudoku.c:281
 msgid "hard"
 msgstr "khó"
 
-#: src/sudoku.c:253
+#: src/sudoku.c:283
 msgid "normal"
 msgstr "thường"
 
-#: src/sudoku.c:256
+#: src/sudoku.c:286
 msgid "easy"
 msgstr "dễ"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ else
 nudoku_LDADD = ${ncurses_LIBS}
 endif
 bin_PROGRAMS = nudoku
-nudoku_SOURCES = main.c sudoku.c sudoku.h
+nudoku_SOURCES = main.c types.h sudoku.c sudoku.h
 
 if BUILD_CAIRO
 nudoku_SOURCES += outp.c outp.h

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <time.h>				/* time */
 #include <string.h>				/* strcmp, strlen */
 #include <locale.h>				/* setlocale */
+#include "types.h"				/* general definitions */
 #include "sudoku.h"				/* sudoku functions */
 #ifdef ENABLE_CAIRO
 #include "outp.h"				/* output functions */
@@ -85,6 +86,7 @@ static char  plain_board[STREAM_LENGTH];
 static char  user_board[STREAM_LENGTH];
 static char* g_outputFilename = NULL;		/* in case -p/-i flag we get a filename passed for outputting */
 static int   g_sudokuCount = 1;				/* in case of -n we can the numbers of sudoku that should end up in the PDf (-p) */
+static PAPER_SIZE g_pdfSize = PS_A4;		/* in case of -S we get the PDF paper size from its name (a4/letter) */
 static bool  g_outIsPDF;
 static DIFFICULTY g_level = D_EASY;
 static WINDOW *grid, *infobox, *status;
@@ -117,6 +119,7 @@ static void print_usage(void)
 	printf(_("-p filename:\t\tOutput PDF\n"));
 	printf(_("-n filename:\t\tNumber of sudokus to put in PDF\n"));
 	printf(_("-i filename:\t\tOutput PNG image\n"));
+	printf(_("-S papername:\t\tPDF paper size ('a4' or 'letter'; default 'a4')\n"));
 }
 
 static bool is_valid_stream(char *s)
@@ -286,7 +289,7 @@ void generate_stream_output(int difficulty) {
 static void parse_arguments(int argc, char *argv[])
 {
 	int opt;
-	while ((opt = getopt(argc, argv, "hvcors:d:p:i:n:")) != -1)
+	while ((opt = getopt(argc, argv, "hvcors:d:p:i:n:S:")) != -1)
 	{
 		switch (opt)
 		{
@@ -345,6 +348,18 @@ static void parse_arguments(int argc, char *argv[])
 			// numbers of sudoku for output pdf
 			case 'n':
 				g_sudokuCount = atoi(optarg);
+				break;
+			// PDF paper size
+			case 'S':
+				if (strcmp(optarg, "letter") == 0)
+					g_pdfSize = PS_LETTER;
+				else if (strcmp(optarg, "a4") == 0)
+					g_pdfSize = PS_A4;
+				else
+				{
+					print_usage();
+					exit(EXIT_FAILURE);
+				}
 				break;
 			default:
 				print_usage();
@@ -665,7 +680,7 @@ int main(int argc, char *argv[])
 	if (g_outputFilename)
 	{
 #ifdef ENABLE_CAIRO
-		generate_output(g_level, g_outputFilename, g_sudokuCount, g_outIsPDF);
+		generate_output(g_level, g_outputFilename, g_sudokuCount, g_outIsPDF, g_pdfSize);
 		return 0;
 #else
 		printf(_("nudoku is compiled without cairo support.\n"));

--- a/src/outp.c
+++ b/src/outp.c
@@ -24,6 +24,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>				/* snprintf() */
 #include <stdlib.h>				/* free() */
 #include "sudoku.h"				/* sudoku functions */
+#include "types.h"				/* general definitions */
 
 /* FUNCTIONS */
 
@@ -73,12 +74,23 @@ void draw_grid(const char* stream, cairo_t *cr)
 	}
 }
 
-void generate_pdf(int difficulty, int sudokus_count, const char* filename)
+// 1 point = 1/72 inch
+PAPER_SIZE convert_in_to_pt(PAPER_SIZE size) {
+	PAPER_SIZE ps_converted;
+
+	ps_converted.width = (size.width * 72) / 100;
+	ps_converted.height = (size.height * 72) / 100;
+
+	return ps_converted;
+}
+
+void generate_pdf(int difficulty, int sudokus_count, PAPER_SIZE paperSize, const char* filename)
 {
 	cairo_surface_t *surface;
 	cairo_t *cr;
 
-	surface = cairo_pdf_surface_create(filename, 595, 842);
+	PAPER_SIZE ps_points = convert_in_to_pt(paperSize);
+	surface = cairo_pdf_surface_create(filename, ps_points.width, ps_points.height);
 	cr = cairo_create(surface);
 
 	cairo_set_source_rgb(cr, 0, 0, 0);
@@ -183,11 +195,11 @@ void generate_png(int difficulty, char* filename)
 	free(stream);
 }
 
-void generate_output(int difficulty, char* filename, int sudokuCount, bool isPDF)
+void generate_output(int difficulty, char* filename, int sudokuCount, bool isPDF, PAPER_SIZE paperSize)
 {
 	if (isPDF)
 	{
-		generate_pdf(difficulty, sudokuCount, filename);
+		generate_pdf(difficulty, sudokuCount, paperSize, filename);
 	} else {
 		generate_png(difficulty, filename);
 	}

--- a/src/outp.c
+++ b/src/outp.c
@@ -75,7 +75,7 @@ void draw_grid(const char* stream, cairo_t *cr)
 }
 
 // 1 point = 1/72 inch
-PAPER_SIZE convert_in_to_pt(PAPER_SIZE size) {
+static PAPER_SIZE convert_in_to_pt(PAPER_SIZE size) {
 	PAPER_SIZE ps_converted;
 
 	ps_converted.width = (size.width * 72) / 100;

--- a/src/outp.h
+++ b/src/outp.h
@@ -3,6 +3,8 @@
 #ifndef OUTP_H
 #define OUTP_H
 
+#include "types.h"
+
 void generate_output(int difficulty, char* filename, int sudokuCount, bool isPDF, PAPER_SIZE paperSize);
 
 #endif // OUTP_H

--- a/src/outp.h
+++ b/src/outp.h
@@ -3,6 +3,6 @@
 #ifndef OUTP_H
 #define OUTP_H
 
-void generate_output(int difficulty, char* filename, int sudokuCount, bool isPDF);
+void generate_output(int difficulty, char* filename, int sudokuCount, bool isPDF, PAPER_SIZE paperSize);
 
 #endif // OUTP_H

--- a/src/types.h
+++ b/src/types.h
@@ -4,12 +4,12 @@
 #define TYPES_H
 
 typedef struct {
-    int width;
-    int height;
+	int width;
+	int height;
 } PAPER_SIZE;
 
 // Size in inches x100, to allow hundredths of an inch.
-static const PAPER_SIZE PS_LETTER = { 850, 1100 };
-static const PAPER_SIZE PS_A4 = { 827, 1169 };
+#define PS_LETTER ((PAPER_SIZE) { 850, 1100 })
+#define PS_A4 ((PAPER_SIZE) { 827, 1169 })
 
 #endif // TYPES_H

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,15 @@
+// vim: noexpandtab:ts=4:sts=4:sw=4
+
+#ifndef TYPES_H
+#define TYPES_H
+
+typedef struct {
+    int width;
+    int height;
+} PAPER_SIZE;
+
+// Size in inches x100, to allow hundredths of an inch.
+static const PAPER_SIZE PS_LETTER = { 850, 1100 };
+static const PAPER_SIZE PS_A4 = { 827, 1169 };
+
+#endif // TYPES_H


### PR DESCRIPTION
This PR solves #72.

Based on https://github.com/jubalh/nudoku/issues/72#issuecomment-2565351470, [Cairo documentation](https://www.cairographics.org/manual/cairo-PDF-Surfaces.html#cairo-pdf-surface-create) defines the units used in `cairo_pdf_surface_create` as _points_:

```c
cairo_surface_t
cairo_pdf_surface_create (const char *filename,
                          double width_in_points,
                          double height_in_points);
```

Furthermore, a point is defined as 1/72 of an inch.

With this information, an additional option `-S papersize` has been added, that accepts the name of a paper size. It currently supports `letter` or `a4`, the latter being the default.

A struct represents the paper size, defined in a new `types.h` file to make it available even without Cairo support compiled (and thus visible to `main.c`):

```c
typedef struct {
    int width;
    int height;
} PAPER_SIZE;
```

Then, constants for each supported size are defined and set in a variable if the option is present:

```c
// Size in inches x100, to allow hundredths of an inch.
static const PAPER_SIZE PS_LETTER = { 850, 1100 };
static const PAPER_SIZE PS_A4 = { 827, 1169 };
```

Finally, in `outp.c`, a function called `convert_in_to_ps` computes the points out of the (inches x 100) defined in the constants:

```c
// 1 point = 1/72 inch
PAPER_SIZE convert_in_to_pt(PAPER_SIZE size) {
	PAPER_SIZE ps_converted;

	ps_converted.width = (size.width * 72) / 100;
	ps_converted.height = (size.height * 72) / 100;

	return ps_converted;
}
```

Doing it like this allows for future support of more paper sizes (by adding more constants), or custom-defined ones (how to provision the size and units must be discussed first).