### PR TITLE
Added autosave and resume key

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -188,7 +188,7 @@ char* get_saved_file_path(void)
 	struct stat st = {0};
 	if (stat(dir_path, &st) == -1)
 		mkdir(dir_path, 0700);
-	
+
 	const char* file_name = STATE_FILE_NAME;
 	size_t len_file = strlen(file_name);
 	size_t len_dir_path = strlen(dir_path);
@@ -961,9 +961,9 @@ int main(int argc, char *argv[])
 					break;
 				}
 
-				default:
-					break;
-			}
+			default:
+				break;
+		}
 		/*if user inputs a number*/
 		if(key >= 49 && key <= 57 && g_playing)
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -188,7 +188,6 @@ char* get_saved_file_path(void)
 	struct stat st = {0};
 	if (stat(dir_path, &st) == -1)
 		mkdir(dir_path, 0700);
-
 	const char* file_name = STATE_FILE_NAME;
 	size_t len_file = strlen(file_name);
 	size_t len_dir_path = strlen(dir_path);
@@ -273,11 +272,16 @@ bool save_stream(char user_board[], char plain_board[], int n)
 	}
 	for ( int i=0; i<n; ++i )
 	{
-		fprintf(fp, "%c", plain_board[i]);
+		fprintf(fp, "%c", plain_board[i]);	
 	}
 	fclose(fp);
 
 	return true;
+}
+
+static void autosave(void) {
+	if (g_playing)
+		save_stream(user_board, plain_board, STREAM_LENGTH);
 }
 
 void generate_stream_output(int difficulty) {
@@ -512,6 +516,7 @@ static void init_windows(void)
 	}
 	wprintw(infobox, _(" N - New puzzle\n"));
 	wprintw(infobox, _(" G - Save\n"));
+	wprintw(infobox, _(" R - Resume from save\n"));
 	wprintw(infobox, _(" Q - Quit\n"));
 	wprintw(infobox, _(" r - Redraw\n"));
 	wprintw(infobox, _(" S - Solve puzzle\n"));
@@ -883,6 +888,7 @@ int main(int argc, char *argv[])
 						undo_stack_push((move_t){x, y, user_board[posy*9+posx]});
 						user_board[posy*9+posx] = '.';
 						wprintw(grid, " ");
+						autosave();
 					}
 					break;
 				}
@@ -893,6 +899,7 @@ int main(int argc, char *argv[])
 					fill_grid(user_board, plain_board, x, y);
 					werase(status);
 					mvwprintw(status, 0, 0, _("Provided hint"));
+					autosave();
 				}
 				break;
 			case 'm':
@@ -911,10 +918,35 @@ int main(int argc, char *argv[])
 					mvwprintw(status, 0, 0, _("Can't save the game!"));
 				}
 				break;
-			case 'u': // Undo
+			case 'R':
+				if (get_board_save(user_board, plain_board))
 				{
-					move_t old_move;
-					if (undo_stack_pop(&old_move))
+					g_useHighlights = false;
+					g_hint_counter = 0;
+					g_undo_stack_index = 0;
+
+					x = GRID_NUMBER_START_X;
+					y = GRID_NUMBER_START_Y;
+					fill_grid(user_board, plain_board, x, y);
+					g_playing = true;
+
+					if (g_provided_stream)
+					{
+						free(g_provided_stream);
+						g_provided_stream = NULL;
+					}
+
+					mvwprintw(status, 0, 0, _("Resumed saved game"));
+				}
+				else
+				{
+					mvwprintw(status, 0, 0, _("No saved game found"));
+				}
+				break;
+			case 'u': // Undo
+			{
+				move_t old_move;
+				if (undo_stack_pop(&old_move))
 					{	// Stack empty
 						break;
 					}
@@ -924,6 +956,7 @@ int main(int argc, char *argv[])
 					posx = (x-GRID_NUMBER_START_X)/GRID_LINE_DELTA;
 					user_board[posy*9+posx] = old_move.prev_val;
 					fill_grid(user_board, plain_board, x, y);
+					autosave();
 					break;
 				}
 
@@ -944,6 +977,7 @@ int main(int argc, char *argv[])
 				user_board[posy*9+posx] = key;
 				// redraw grid to update highlight
 				fill_grid(user_board, plain_board, x, y);
+				autosave();
 			}
 		}
 		wmove(grid, y,x);

--- a/src/main.c
+++ b/src/main.c
@@ -948,18 +948,18 @@ int main(int argc, char *argv[])
 				{
 					move_t old_move;
 					if (undo_stack_pop(&old_move))
-						{	// Stack empty
-							break;
-						}
-						x = old_move.x;
-						y = old_move.y;
-						posy = (y-GRID_NUMBER_START_Y)/GRID_COL_DELTA;
-						posx = (x-GRID_NUMBER_START_X)/GRID_LINE_DELTA;
-						user_board[posy*9+posx] = old_move.prev_val;
-						fill_grid(user_board, plain_board, x, y);
-						autosave();
+					{	// Stack empty
 						break;
 					}
+					x = old_move.x;
+					y = old_move.y;
+					posy = (y-GRID_NUMBER_START_Y)/GRID_COL_DELTA;
+					posx = (x-GRID_NUMBER_START_X)/GRID_LINE_DELTA;
+					user_board[posy*9+posx] = old_move.prev_val;
+					fill_grid(user_board, plain_board, x, y);
+					autosave();
+					break;
+				}
 
 				default:
 					break;

--- a/src/main.c
+++ b/src/main.c
@@ -188,6 +188,7 @@ char* get_saved_file_path(void)
 	struct stat st = {0};
 	if (stat(dir_path, &st) == -1)
 		mkdir(dir_path, 0700);
+	
 	const char* file_name = STATE_FILE_NAME;
 	size_t len_file = strlen(file_name);
 	size_t len_dir_path = strlen(dir_path);
@@ -272,7 +273,7 @@ bool save_stream(char user_board[], char plain_board[], int n)
 	}
 	for ( int i=0; i<n; ++i )
 	{
-		fprintf(fp, "%c", plain_board[i]);	
+		fprintf(fp, "%c", plain_board[i]);
 	}
 	fclose(fp);
 
@@ -944,25 +945,25 @@ int main(int argc, char *argv[])
 				}
 				break;
 			case 'u': // Undo
-			{
-				move_t old_move;
-				if (undo_stack_pop(&old_move))
-					{	// Stack empty
+				{
+					move_t old_move;
+					if (undo_stack_pop(&old_move))
+						{	// Stack empty
+							break;
+						}
+						x = old_move.x;
+						y = old_move.y;
+						posy = (y-GRID_NUMBER_START_Y)/GRID_COL_DELTA;
+						posx = (x-GRID_NUMBER_START_X)/GRID_LINE_DELTA;
+						user_board[posy*9+posx] = old_move.prev_val;
+						fill_grid(user_board, plain_board, x, y);
+						autosave();
 						break;
 					}
-					x = old_move.x;
-					y = old_move.y;
-					posy = (y-GRID_NUMBER_START_Y)/GRID_COL_DELTA;
-					posx = (x-GRID_NUMBER_START_X)/GRID_LINE_DELTA;
-					user_board[posy*9+posx] = old_move.prev_val;
-					fill_grid(user_board, plain_board, x, y);
-					autosave();
-					break;
-				}
 
-			default:
-				break;
-		}
+				default:
+					break;
+			}
 		/*if user inputs a number*/
 		if(key >= 49 && key <= 57 && g_playing)
 		{


### PR DESCRIPTION
I created a autosave function that uses the existing save_stream function to save the stream to "state.save". However, autosave does not rely on manually pressing 'G' but saves every time the user deletes a number, gets a hint, undoes an action, or when a user inputs a number into the board.

I also created a new key 'R' which allows the user to resume their last saved game either from manually pressing 'G' or from the new autosave function. This essentially does the same thing as if you passed the -r flag when running nsudoku.
